### PR TITLE
Use more compatible shell

### DIFF
--- a/templates/hooks/commit-msg
+++ b/templates/hooks/commit-msg
@@ -2,15 +2,15 @@
 #
 # This hook will attempt to setup your environment before running checks.
 
-if which rvm >&/dev/null
+if which rvm > /dev/null 2>&1
 then cmd="rvm default do ruby"
-elif which rbenv >&/dev/null
+elif which rbenv > /dev/null 2>&1
 then cmd="rbenv exec ruby"
 else cmd="ruby"
 fi
 
 export COMMIT_MESSAGE_PATH=$1
-if (! [[ "$COMMIT_MESSAGE_PATH" ]] ); then
+if [ -z "$COMMIT_MESSAGE_PATH" ]; then
   >&2 echo "fit-commit: WARNING: Skipping checks because the Git hook was not passed the"
   >&2 echo "fit-commit: commit message file path. This is usually \`.git/COMMIT_EDITMSG\`."
   >&2 echo "fit-commit: This hook was called via: $0 $*"
@@ -19,7 +19,7 @@ if (! [[ "$COMMIT_MESSAGE_PATH" ]] ); then
 fi
 
 export GIT_BRANCH_NAME=`git name-rev --name-only HEAD`
-if (! [[ "$GIT_BRANCH_NAME" ]] ); then
+if [ -z "$GIT_BRANCH_NAME" ]; then
   >&2 echo "fit-commit: WARNING: Skipping checks because the Git branch cannot be determined."
   >&2 echo "fit-commit: Please submit a bug report with the project."
   exit 0


### PR DESCRIPTION
On Debian sh is linked with dash shell. Got errors like:

```
.git/hooks/commit-msg: 11: .git/hooks/commit-msg: Syntax error: Bad fd number
.git/hooks/commit-msg: 13: .git/hooks/commit-msg: [[: not found
```

Cheers