### PR TITLE
Skip capital letter check for fixup and squash commits title

### DIFF
--- a/lib/fit_commit/validators/capitalize_subject.rb
+++ b/lib/fit_commit/validators/capitalize_subject.rb
@@ -3,8 +3,10 @@ require "fit_commit/validators/base"
 module FitCommit
   module Validators
     class CapitalizeSubject < Base
+      AUTOSQUASH = /\A(fixup|squash)! /
+
       def validate_line(lineno, text)
-        if lineno == 1 && text[0] =~ /[[:lower:]]/
+        if lineno == 1 && text[0] =~ /[[:lower:]]/ && text !~ AUTOSQUASH
           add_error(lineno, "Begin all subject lines with a capital letter.")
         end
       end

--- a/test/unit/validators/capitalize_subject_test.rb
+++ b/test/unit/validators/capitalize_subject_test.rb
@@ -17,6 +17,22 @@ describe FitCommit::Validators::CapitalizeSubject do
       assert_empty validator.warnings
     end
   end
+  describe "subject is fixup commit" do
+    let(:commit_msg) { "fixup! foo bar" }
+    it "does not have errors/warnings" do
+      validator.validate(commit_lines)
+      assert_empty validator.errors
+      assert_empty validator.warnings
+    end
+  end
+  describe "subject is squash commit" do
+    let(:commit_msg) { "squash! foo bar" }
+    it "does not have errors/warnings" do
+      validator.validate(commit_lines)
+      assert_empty validator.errors
+      assert_empty validator.warnings
+    end
+  end
   describe "subject is capitalized" do
     let(:commit_msg) { "Foo bar" }
     it "does not have errors/warnings" do


### PR DESCRIPTION
Hey,

I noticed that fit-commit get offended when I try to commit a fixup or squash commit using [autosquash](https://robots.thoughtbot.com/autosquashing-git-commits) behavior:
```
git commit --fixup=4dd5166
git commit --squash=4dd5166
```

I've changed capital letter validator a bit, to just skip that kind of commits. @m1foley, do you find it useful?