### PR TITLE
Add bundler support

### DIFF
--- a/templates/hooks/commit-msg
+++ b/templates/hooks/commit-msg
@@ -22,13 +22,30 @@ export GIT_BRANCH_NAME=`git symbolic-ref --short HEAD 2> /dev/null`
 
 # find appropriate Ruby command
 if which rbenv > /dev/null 2>&1; then
-  cmd="rbenv exec ruby"
+  if [ -e Gemfile ]; then
+    cmd="rbenv exec bundle exec ruby"
+  else
+    cmd="rbenv exec ruby"
+  fi
 elif which ruby-rvm-env > /dev/null 2>&1; then
   cmd="ruby-rvm-env"
+  if [ -e Gemfile ]; then
+    cmd="bundle exec ruby-rvm-env"
+  else
+    cmd="ruby-rvm-env"
+  fi
 elif which rvm > /dev/null 2>&1; then
-  cmd="rvm default do ruby"
+  if [ -e Gemfile ]; then
+    cmd="rvm default do bundle exec ruby"
+  else
+    cmd="rvm default do ruby"
+  fi
 else
-  cmd="ruby"
+  if [ -e Gemfile ]; then
+    cmd="bundle exec ruby"
+  else
+    cmd="ruby"
+  fi
 fi
 
 # allow user input if running in a terminal


### PR DESCRIPTION
According to the bundler documentation, preferable method to run ruby is `bundle exec ruby`

> In some cases, running executables without bundle exec may work, if the executable happens to be installed in your system and does not pull in any gems that conflict with your bundle.
> 
> However, this is unreliable and is the source of considerable pain. Even if it looks like it works, it may not work in the future or on another machine.
> 
