### PR TITLE
Use bundler if fit-commit was installed using it

### DIFF
--- a/templates/hooks/commit-msg
+++ b/templates/hooks/commit-msg
@@ -20,8 +20,11 @@ fi
 
 export GIT_BRANCH_NAME=`git symbolic-ref --short HEAD 2> /dev/null`
 
-# find appropriate Ruby command
-if which rbenv > /dev/null 2>&1; then
+# Use bundler if fit-commit was installed using it
+# or find appropriate Ruby command
+if bundle show fit-commit > /dev/null 2>&1; then
+  cmd="bundle exec ruby"
+elif which rbenv > /dev/null 2>&1; then
   cmd="rbenv exec ruby"
 elif which ruby-rvm-env > /dev/null 2>&1; then
   cmd="ruby-rvm-env"


### PR DESCRIPTION
Bundler will install gems to a different path, which most likely won't be picked
up by ruby. So use `bundle exec` to run ruby to ensure gem path is correctly set
for fit-commit.