### PR TITLE
Detect and initialise Rubymine to support running within non-interactive shells

### DIFF
--- a/templates/hooks/commit-msg
+++ b/templates/hooks/commit-msg
@@ -20,6 +20,14 @@ fi
 
 export GIT_BRANCH_NAME=`git symbolic-ref --short HEAD 2> /dev/null`
 
+# If this script is being run from a non interactive shell
+# (i.e. from within RubyMine) then we might need to
+# detect and initialise rbenv.
+if [ -d $HOME/.rbenv ]; then
+  export PATH="$HOME/.rbenv/bin:$PATH"
+  eval "$(rbenv init -)"
+fi
+
 # Use bundler if fit-commit was installed using it
 # or find appropriate Ruby command
 if bundle show fit-commit > /dev/null 2>&1; then


### PR DESCRIPTION
*Acceptance Criteria:*

    As a user of rbenv
    When I commit via something other than an interactive shell (i.e. from RubyMine)
    Then I want fit-commit to work normally

I discovered that fit-commit will fail to find Ruby when Ruby is installed via rbenv and the commit hook is triggered by something other than an interactive shell e.g. from an IDE. It seems in this case rbenv is not initialised (presumably because there is no shell initialisation performed).  

I'm not very familiar with fit-commit (I've just started working on a project which was already using it) so there may be some things I haven't considered. Thought I'd offer this as a conversation starter though.

Cheers!

Edd
