### PR TITLE
Do not exit with error when help running

### DIFF
--- a/lib/fit_commit/cli.rb
+++ b/lib/fit_commit/cli.rb
@@ -23,7 +23,7 @@ module FitCommit
       $stderr.puts "fit-commit v#{FitCommit::VERSION}"
       $stderr.puts "Usage: fit-commit install"
       $stderr.puts "Usage: fit-commit uninstall"
-      EXIT_CODE_FAILURE
+      EXIT_CODE_SUCCESS
     end
 
     def install


### PR DESCRIPTION
I'm trying to detect if `fit-commit` is installed on a machine. I mean if it's available as a CLI, instead of a dependency of a project. However, 'fit-commit' command is always returning help + `FAILURE` code even if it's installed.

This PR changes the status code of `help` method.